### PR TITLE
`application`: bug: remove unsupported parameters

### DIFF
--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -32,9 +32,7 @@ func TestAccResourceApplication(t *testing.T) {
 
 	appGit := &model.ApplicationGitPath{
 		Repo: &model.ApplicationGitRepository{
-			Id:     "repo_id",
-			Remote: "repo_remote",
-			Branch: "main",
+			Id: "repo_id",
 		},
 		Path:           "path/to/config",
 		ConfigFilename: "testapp.pipecd.yaml",
@@ -87,8 +85,6 @@ func TestAccResourceApplication(t *testing.T) {
 					resource.TestCheckResourceAttr("pipecd_application.test", "platform_provider", "test_provider"),
 					resource.TestCheckResourceAttr("pipecd_application.test", "description", "test description"),
 					resource.TestCheckResourceAttr("pipecd_application.test", "git.repository_id", "repo_id"),
-					resource.TestCheckResourceAttr("pipecd_application.test", "git.remote", "repo_remote"),
-					resource.TestCheckResourceAttr("pipecd_application.test", "git.branch", "main"),
 					resource.TestCheckResourceAttr("pipecd_application.test", "git.path", "path/to/config"),
 					resource.TestCheckResourceAttr("pipecd_application.test", "git.filename", "testapp.pipecd.yaml"),
 				),
@@ -107,8 +103,6 @@ resource "pipecd_application" "test" {
 	description = "test description"
 	git = {
 		repository_id = "repo_id"
-		remote = "repo_remote"
-		branch = "main"
 		path = "path/to/config"
 		filename = "testapp.pipecd.yaml"
 	}

--- a/internal/provider/resource_piped.go
+++ b/internal/provider/resource_piped.go
@@ -148,7 +148,7 @@ func (p *PipedResource) Create(ctx context.Context, req resource.CreateRequest, 
 		Description: types.StringValue(piped.Desc),
 		APIKey:      types.StringValue(registerResp.Key),
 	}
-	diags = resp.State.Set(ctx, plan)
+	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -188,7 +188,7 @@ func (p *PipedResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	diags = resp.State.Set(ctx, plan)
+	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
 


### PR DESCRIPTION
Both `branch` and `remote` are not supported.