### PR TITLE
Fix typo of default value for application

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -169,7 +169,7 @@ func (a *ApplicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Description: "The configuration file name. (default \"app.pipecd.yaml\")",
 						Optional:    true,
 						Computed:    true,
-						Default:     stringdefault.StaticString("app.piped.yaml"),
+						Default:     stringdefault.StaticString("app.pipecd.yaml"),
 					},
 				},
 			},


### PR DESCRIPTION
The default value for appication file name is `app.pipecd.yaml`.
https://pipecd.dev/docs-dev/user-guide/managing-application/adding-an-application/
