### PR TITLE
fix go version

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.23.2'
           cache: true
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.23.2'
           cache: true
       - name: Run tests
         run: make testacc


### PR DESCRIPTION
The recently patch added the go toolchain version and has already failed workflow. That is why the setup-go uses go.mod version (1.22.7), but Go uses toolchain version (1.23.2).

```
Run actions/setup-go@v5
Setup go version spec 1.22.[7](https://github.com/pipe-cd/terraform-provider-pipecd/actions/runs/11932893110/job/33258806657#step:3:8)
Attempting to download 1.22.7...
matching 1.22.7...
Acquiring 1.22.7 from https://github.com/actions/go-versions/releases/download/1.22.7-107322763[8](https://github.com/pipe-cd/terraform-provider-pipecd/actions/runs/11932893110/job/33258806657#step:3:9)4/go-1.22.7-linux-x64.tar.gz
Extracting Go...
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/573a651e-8fbf-45fe-ae4[9](https://github.com/pipe-cd/terraform-provider-pipecd/actions/runs/11932893110/job/33258806657#step:3:10)-c2fe1cc5d909 -f /home/runner/work/_temp/0965c43b-9e62-4ef1-aa87-bd6788527cc4
Successfully extracted go to /home/runner/work/_temp/573a651e-8fbf-45fe-ae49-c2fe1cc5d909
Adding to the cache ...
Successfully cached go to /opt/hostedtoolcache/go/1.22.7/x64
Added go to the path
Successfully set up Go version 1.22.7
go: downloading go1.23.2 (linux/amd64)
/opt/hostedtoolcache/go/1.22.7/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.22.7/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Cache is not found
go version go1.23.2 linux/amd64
```